### PR TITLE
Added config column to detail_properties collection

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -68,6 +68,7 @@ class BaseProperty(ABC):
     name: str
     path: str
     order: int
+    config: Optional[Dict] = None
 
     def get_path(self):
         """

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -261,7 +261,8 @@ async def by_id(dataset_connector: DatasetConnectorDep, dataset: DatasetDep,
             {
                 "name": prop.name,
                 "type": prop.type,
-                "value": jsonpath.findall(prop.path, item_data)[0]
+                "value": jsonpath.findall(prop.path, item_data)[0],
+                "config": prop.config
             } for prop in properties
         ]
     }


### PR DESCRIPTION
Add an (optional) config column to the details properties collection, for storing type-related configuration of the Panoptes details view.